### PR TITLE
Update tokens to use number literals

### DIFF
--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -15,7 +15,11 @@ type NumberChar = Digit | ".";
  * A NumberToken stores the exact digits as literal type V.
  * Example: NumberToken<"42">
  */
-export interface NumberToken<V extends string> {
+type StrToNumber<S extends string> = S extends `${infer N extends number}`
+  ? N
+  : never;
+
+export interface NumberToken<V extends number> {
   type: "number";
   value: V;
 }
@@ -31,7 +35,7 @@ export interface ParenToken {
 }
 
 /** A token is either a NumberToken, OperatorToken, or ParenToken. */
-type Token = NumberToken<string> | OperatorToken | ParenToken;
+type Token = NumberToken<number> | OperatorToken | ParenToken;
 
 /** A list of tokens (possibly empty) */
 export type TokenList = Token[];
@@ -54,8 +58,8 @@ type TokenizeNumber<
         ? never // Second decimal point is invalid
         : TokenizeNumber<Rest, `${Acc}${C}`, true>
       : TokenizeNumber<Rest, `${Acc}${C}`, HasDecimal>
-    : [{ type: "number"; value: Acc }, S]
-  : [{ type: "number"; value: Acc }, S];
+    : [{ type: "number"; value: StrToNumber<Acc> }, S]
+  : [{ type: "number"; value: StrToNumber<Acc> }, S];
 
 type TokenizeOne<S extends string> = TrimLeft<S> extends ""
   ? // nothing left => no token

--- a/tests/tokenize.test.ts
+++ b/tests/tokenize.test.ts
@@ -4,7 +4,7 @@ import { Expect, Equal } from "./test_utilities";
 
 /**
  * 1. Single literal
- * "5" => [{ type: "number"; value: "5" }]
+ * "5" => [{ type: "number"; value: 5 }]
  */
 type TokenSingleLiteral = Expect<
   Equal<
@@ -12,7 +12,7 @@ type TokenSingleLiteral = Expect<
     [
       {
         type: "number";
-        value: "5";
+        value: 5;
       }
     ]
   >
@@ -20,27 +20,27 @@ type TokenSingleLiteral = Expect<
 
 /**
  * 2. Double digit number
- * "42" => [{ type: "number"; value: "42" }]
+ * "42" => [{ type: "number"; value: 42 }]
  */
 type TokenDoubleDigitNumber = Expect<
-  Equal<Tokenize<"42">, [{ type: "number"; value: "42" }]>
+  Equal<Tokenize<"42">, [{ type: "number"; value: 42 }]>
 >;
 
 /**
  * 3. Simple sum
  * "5 + 3" => [
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenSimpleSum = Expect<
   Equal<
     Tokenize<"5 + 3">,
     [
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
@@ -48,18 +48,18 @@ type TokenSimpleSum = Expect<
 /**
  * 4. Simple subtraction
  * "10 - 4" => [
- *   { type: "number"; value: "10" },
+ *   { type: "number"; value: 10 },
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "4" }
+ *   { type: "number"; value: 4 }
  * ]
  */
 type TokenSimpleSubtraction = Expect<
   Equal<
     Tokenize<"10 - 4">,
     [
-      { type: "number"; value: "10" },
+      { type: "number"; value: 10 },
       { type: "operator"; value: "-" },
-      { type: "number"; value: "4" }
+      { type: "number"; value: 4 }
     ]
   >
 >;
@@ -67,18 +67,18 @@ type TokenSimpleSubtraction = Expect<
 /**
  * 5. Simple multiplication
  * "6 * 7" => [
- *   { type: "number"; value: "6" },
+ *   { type: "number"; value: 6 },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "7" }
+ *   { type: "number"; value: 7 }
  * ]
  */
 type TokenSimpleMultiplication = Expect<
   Equal<
     Tokenize<"6 * 7">,
     [
-      { type: "number"; value: "6" },
+      { type: "number"; value: 6 },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "7" }
+      { type: "number"; value: 7 }
     ]
   >
 >;
@@ -86,18 +86,18 @@ type TokenSimpleMultiplication = Expect<
 /**
  * 6. Simple division
  * "20 / 5" => [
- *   { type: "number"; value: "20" },
+ *   { type: "number"; value: 20 },
  *   { type: "operator"; value: "/" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenSimpleDivision = Expect<
   Equal<
     Tokenize<"20 / 5">,
     [
-      { type: "number"; value: "20" },
+      { type: "number"; value: 20 },
       { type: "operator"; value: "/" },
-      { type: "number"; value: "5" }
+      { type: "number"; value: 5 }
     ]
   >
 >;
@@ -105,18 +105,18 @@ type TokenSimpleDivision = Expect<
 /**
  * 7. Modulo operation
  * "7 % 3" => [
- *   { type: "number"; value: "7" },
+ *   { type: "number"; value: 7 },
  *   { type: "operator"; value: "%" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenModuloOperation = Expect<
   Equal<
     Tokenize<"7 % 3">,
     [
-      { type: "number"; value: "7" },
+      { type: "number"; value: 7 },
       { type: "operator"; value: "%" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
@@ -124,18 +124,18 @@ type TokenModuloOperation = Expect<
 /**
  * 8. Exponentiation
  * "2 ^ 3" => [
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "^" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenExponentiation = Expect<
   Equal<
     Tokenize<"2 ^ 3">,
     [
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "^" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
@@ -143,22 +143,22 @@ type TokenExponentiation = Expect<
 /**
  * 9. Mixed operators, shallow nesting
  * "5 + 3 * 2" => [
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenMixedOperators = Expect<
   Equal<
     Tokenize<"5 + 3 * 2">,
     [
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;
@@ -167,12 +167,12 @@ type TokenMixedOperators = Expect<
  * 10. Parentheses affecting operation order
  * "(5 + 3) * 2" => [
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "paren"; value: ")" },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenParenthesesOrder = Expect<
@@ -180,12 +180,12 @@ type TokenParenthesesOrder = Expect<
     Tokenize<"(5 + 3) * 2">,
     [
       { type: "paren"; value: "(" },
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "paren"; value: ")" },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;
@@ -193,22 +193,22 @@ type TokenParenthesesOrder = Expect<
 /**
  * 11. Multiple exponentiations
  * "2 ^ 3 ^ 2" => [
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "^" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "^" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenMultipleExponentiations = Expect<
   Equal<
     Tokenize<"2 ^ 3 ^ 2">,
     [
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "^" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "^" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;
@@ -217,15 +217,15 @@ type TokenMultipleExponentiations = Expect<
  * 12. Multiple parentheses with different operations
  * "(2 + 3) * (4 + 5)" => [
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "paren"; value: ")" },
  *   { type: "operator"; value: "*" },
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "4" },
+ *   { type: "number"; value: 4 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "paren"; value: ")" }
  * ]
  */
@@ -234,15 +234,15 @@ type TokenMultipleParentheses = Expect<
     Tokenize<"(2 + 3) * (4 + 5)">,
     [
       { type: "paren"; value: "(" },
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "paren"; value: ")" },
       { type: "operator"; value: "*" },
       { type: "paren"; value: "(" },
-      { type: "number"; value: "4" },
+      { type: "number"; value: 4 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "paren"; value: ")" }
     ]
   >
@@ -251,57 +251,57 @@ type TokenMultipleParentheses = Expect<
 /**
  * 13. Complex multiplication with parentheses
  * "2 * (3 + 4) * 5" => [
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "*" },
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "4" },
+ *   { type: "number"; value: 4 },
  *   { type: "paren"; value: ")" },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenComplexMultiplication = Expect<
   Equal<
     Tokenize<"2 * (3 + 4) * 5">,
     [
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "*" },
       { type: "paren"; value: "(" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "4" },
+      { type: "number"; value: 4 },
       { type: "paren"; value: ")" },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "5" }
+      { type: "number"; value: 5 }
     ]
   >
 >;
 
 /**
  * 14. Decimal number literal
- * "3.14" => [{ type: "number"; value: "3.14" }]
+ * "3.14" => [{ type: "number"; value: 3.14 }]
  */
 type TokenDecimalLiteral = Expect<
-  Equal<Tokenize<"3.14">, [{ type: "number"; value: "3.14" }]>
+  Equal<Tokenize<"3.14">, [{ type: "number"; value: 3.14 }]>
 >;
 
 /**
  * 15. Simple decimal sum
  * "1.5 + 2.5" => [
- *   { type: "number"; value: "1.5" },
+ *   { type: "number"; value: 1.5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "2.5" }
+ *   { type: "number"; value: 2.5 }
  * ]
  */
 type TokenDecimalSum = Expect<
   Equal<
     Tokenize<"1.5 + 2.5">,
     [
-      { type: "number"; value: "1.5" },
+      { type: "number"; value: 1.5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "2.5" }
+      { type: "number"; value: 2.5 }
     ]
   >
 >;
@@ -309,18 +309,18 @@ type TokenDecimalSum = Expect<
 /**
  * 16. Decimal multiplication
  * "2 * 3.5" => [
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "3.5" }
+ *   { type: "number"; value: 3.5 }
  * ]
  */
 type TokenDecimalMultiplication = Expect<
   Equal<
     Tokenize<"2 * 3.5">,
     [
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "3.5" }
+      { type: "number"; value: 3.5 }
     ]
   >
 >;
@@ -328,18 +328,18 @@ type TokenDecimalMultiplication = Expect<
 /**
  * 17. Decimal division
  * "10 / 2.5" => [
- *   { type: "number"; value: "10" },
+ *   { type: "number"; value: 10 },
  *   { type: "operator"; value: "/" },
- *   { type: "number"; value: "2.5" }
+ *   { type: "number"; value: 2.5 }
  * ]
  */
 type TokenDecimalDivision = Expect<
   Equal<
     Tokenize<"10 / 2.5">,
     [
-      { type: "number"; value: "10" },
+      { type: "number"; value: 10 },
       { type: "operator"; value: "/" },
-      { type: "number"; value: "2.5" }
+      { type: "number"; value: 2.5 }
     ]
   >
 >;
@@ -347,18 +347,18 @@ type TokenDecimalDivision = Expect<
 /**
  * 18. Decimal exponentiation
  * "2.5 ^ 2" => [
- *   { type: "number"; value: "2.5" },
+ *   { type: "number"; value: 2.5 },
  *   { type: "operator"; value: "^" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenDecimalExponentiation = Expect<
   Equal<
     Tokenize<"2.5 ^ 2">,
     [
-      { type: "number"; value: "2.5" },
+      { type: "number"; value: 2.5 },
       { type: "operator"; value: "^" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;
@@ -367,12 +367,12 @@ type TokenDecimalExponentiation = Expect<
  * 19. Decimal parentheses
  * "(1.5 + 0.5) * 2" => [
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "1.5" },
+ *   { type: "number"; value: 1.5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "0.5" },
+ *   { type: "number"; value: 0.5 },
  *   { type: "paren"; value: ")" },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenDecimalParentheses = Expect<
@@ -380,12 +380,12 @@ type TokenDecimalParentheses = Expect<
     Tokenize<"(1.5 + 0.5) * 2">,
     [
       { type: "paren"; value: "(" },
-      { type: "number"; value: "1.5" },
+      { type: "number"; value: 1.5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "0.5" },
+      { type: "number"; value: 0.5 },
       { type: "paren"; value: ")" },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;
@@ -393,22 +393,22 @@ type TokenDecimalParentheses = Expect<
 /**
  * 20. Mixed decimal and integer operations
  * "3 + 2 * 1.5" => [
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "1.5" }
+ *   { type: "number"; value: 1.5 }
  * ]
  */
 type TokenMixedDecimalInteger = Expect<
   Equal<
     Tokenize<"3 + 2 * 1.5">,
     [
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "1.5" }
+      { type: "number"; value: 1.5 }
     ]
   >
 >;
@@ -417,13 +417,13 @@ type TokenMixedDecimalInteger = Expect<
  * 21. Unary minus
  * "-5" => [
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenUnaryMinus = Expect<
   Equal<
     Tokenize<"-5">,
-    [{ type: "operator"; value: "-" }, { type: "number"; value: "5" }]
+    [{ type: "operator"; value: "-" }, { type: "number"; value: 5 }]
   >
 >;
 
@@ -431,13 +431,13 @@ type TokenUnaryMinus = Expect<
  * 22. Unary plus
  * "+5" => [
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenUnaryPlus = Expect<
   Equal<
     Tokenize<"+5">,
-    [{ type: "operator"; value: "+" }, { type: "number"; value: "5" }]
+    [{ type: "operator"; value: "+" }, { type: "number"; value: 5 }]
   >
 >;
 
@@ -445,33 +445,33 @@ type TokenUnaryPlus = Expect<
  * 23. Unary minus with decimal
  * "-3.14" => [
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "3.14" }
+ *   { type: "number"; value: 3.14 }
  * ]
  */
 type TokenUnaryMinusDecimal = Expect<
   Equal<
     Tokenize<"-3.14">,
-    [{ type: "operator"; value: "-" }, { type: "number"; value: "3.14" }]
+    [{ type: "operator"; value: "-" }, { type: "number"; value: 3.14 }]
   >
 >;
 
 /**
  * 24. Unary minus in expression
  * "5 + -3" => [
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "+" },
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenUnaryMinusExpression = Expect<
   Equal<
     Tokenize<"5 + -3">,
     [
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "+" },
       { type: "operator"; value: "-" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
@@ -480,9 +480,9 @@ type TokenUnaryMinusExpression = Expect<
  * 25. Unary minus with multiplication
  * "-5 * 2" => [
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "*" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenUnaryMinusMultiplication = Expect<
@@ -490,9 +490,9 @@ type TokenUnaryMinusMultiplication = Expect<
     Tokenize<"-5 * 2">,
     [
       { type: "operator"; value: "-" },
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "*" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;
@@ -502,9 +502,9 @@ type TokenUnaryMinusMultiplication = Expect<
  * "-(5 + 2)" => [
  *   { type: "operator"; value: "-" },
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "paren"; value: ")" }
  * ]
  */
@@ -514,9 +514,9 @@ type TokenUnaryMinusParentheses = Expect<
     [
       { type: "operator"; value: "-" },
       { type: "paren"; value: "(" },
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "paren"; value: ")" }
     ]
   >
@@ -527,9 +527,9 @@ type TokenUnaryMinusParentheses = Expect<
  * "- (5 + 2)" => [
  *   { type: "operator"; value: "-" },
  *   { type: "paren"; value: "(" },
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "paren"; value: ")" }
  * ]
  */
@@ -539,9 +539,9 @@ type TokenUnaryMinusSpaceParentheses = Expect<
     [
       { type: "operator"; value: "-" },
       { type: "paren"; value: "(" },
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "paren"; value: ")" }
     ]
   >
@@ -552,7 +552,7 @@ type TokenUnaryMinusSpaceParentheses = Expect<
  * "- -5" => [
  *   { type: "operator"; value: "-" },
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenDoubleUnaryMinus = Expect<
@@ -561,7 +561,7 @@ type TokenDoubleUnaryMinus = Expect<
     [
       { type: "operator"; value: "-" },
       { type: "operator"; value: "-" },
-      { type: "number"; value: "5" }
+      { type: "number"; value: 5 }
     ]
   >
 >;
@@ -571,7 +571,7 @@ type TokenDoubleUnaryMinus = Expect<
  * "+ +5" => [
  *   { type: "operator"; value: "+" },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenDoubleUnaryPlus = Expect<
@@ -580,7 +580,7 @@ type TokenDoubleUnaryPlus = Expect<
     [
       { type: "operator"; value: "+" },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "5" }
+      { type: "number"; value: 5 }
     ]
   >
 >;
@@ -590,7 +590,7 @@ type TokenDoubleUnaryPlus = Expect<
  * "+-5" => [
  *   { type: "operator"; value: "+" },
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenUnaryPlusMinus = Expect<
@@ -599,7 +599,7 @@ type TokenUnaryPlusMinus = Expect<
     [
       { type: "operator"; value: "+" },
       { type: "operator"; value: "-" },
-      { type: "number"; value: "5" }
+      { type: "number"; value: 5 }
     ]
   >
 >;
@@ -609,7 +609,7 @@ type TokenUnaryPlusMinus = Expect<
  * "-+5" => [
  *   { type: "operator"; value: "-" },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "5" }
+ *   { type: "number"; value: 5 }
  * ]
  */
 type TokenUnaryMinusPlus = Expect<
@@ -618,7 +618,7 @@ type TokenUnaryMinusPlus = Expect<
     [
       { type: "operator"; value: "-" },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "5" }
+      { type: "number"; value: 5 }
     ]
   >
 >;
@@ -626,24 +626,24 @@ type TokenUnaryMinusPlus = Expect<
 /**
  * 32. Unary minus in complex expression
  * "2 * -3 + 4" => [
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "*" },
  *   { type: "operator"; value: "-" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "4" }
+ *   { type: "number"; value: 4 }
  * ]
  */
 type TokenUnaryMinusComplex = Expect<
   Equal<
     Tokenize<"2 * -3 + 4">,
     [
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "*" },
       { type: "operator"; value: "-" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "4" }
+      { type: "number"; value: 4 }
     ]
   >
 >;
@@ -651,64 +651,64 @@ type TokenUnaryMinusComplex = Expect<
 /**
  * 33. Unary plus in complex expression
  * "2 * +3 + 4" => [
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "*" },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "+" },
- *   { type: "number"; value: "4" }
+ *   { type: "number"; value: 4 }
  * ]
  */
 type TokenUnaryPlusComplex = Expect<
   Equal<
     Tokenize<"2 * +3 + 4">,
     [
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "*" },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "+" },
-      { type: "number"; value: "4" }
+      { type: "number"; value: 4 }
     ]
   >
 >;
 /**
  * 34. Bitwise AND
  * "5 & 3" => [
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "&" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenBitwiseAnd = Expect<
   Equal<
     Tokenize<"5 & 3">,
     [
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "&" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
 /**
  * 35. Bitwise AND chain
  * "8 & 3 & 1" => [
- *   { type: "number"; value: "8" },
+ *   { type: "number"; value: 8 },
  *   { type: "operator"; value: "&" },
- *   { type: "number"; value: "3" },
+ *   { type: "number"; value: 3 },
  *   { type: "operator"; value: "&" },
- *   { type: "number"; value: "1" }
+ *   { type: "number"; value: 1 }
  * ]
  */
 type TokenAndChain = Expect<
   Equal<
     Tokenize<"8 & 3 & 1">,
     [
-      { type: "number"; value: "8" },
+      { type: "number"; value: 8 },
       { type: "operator"; value: "&" },
-      { type: "number"; value: "3" },
+      { type: "number"; value: 3 },
       { type: "operator"; value: "&" },
-      { type: "number"; value: "1" }
+      { type: "number"; value: 1 }
     ]
   >
 >;
@@ -716,18 +716,18 @@ type TokenAndChain = Expect<
 /**
  * 36. Bitwise AND with zero
  * "7 & 0" => [
- *   { type: "number"; value: "7" },
+ *   { type: "number"; value: 7 },
  *   { type: "operator"; value: "&" },
- *   { type: "number"; value: "0" }
+ *   { type: "number"; value: 0 }
  * ]
  */
 type TokenAndZero = Expect<
   Equal<
     Tokenize<"7 & 0">,
     [
-      { type: "number"; value: "7" },
+      { type: "number"; value: 7 },
       { type: "operator"; value: "&" },
-      { type: "number"; value: "0" }
+      { type: "number"; value: 0 }
     ]
   >
 >;
@@ -735,18 +735,18 @@ type TokenAndZero = Expect<
 /**
  * 37. Bitwise OR
  * "5 | 3" => [
- *   { type: "number"; value: "5" },
+ *   { type: "number"; value: 5 },
  *   { type: "operator"; value: "|" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenOrSimple = Expect<
   Equal<
     Tokenize<"5 | 3">,
     [
-      { type: "number"; value: "5" },
+      { type: "number"; value: 5 },
       { type: "operator"; value: "|" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
@@ -754,22 +754,22 @@ type TokenOrSimple = Expect<
 /**
  * 38. Bitwise OR chain
  * "1 | 2 | 4" => [
- *   { type: "number"; value: "1" },
+ *   { type: "number"; value: 1 },
  *   { type: "operator"; value: "|" },
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "|" },
- *   { type: "number"; value: "4" }
+ *   { type: "number"; value: 4 }
  * ]
  */
 type TokenOrChain = Expect<
   Equal<
     Tokenize<"1 | 2 | 4">,
     [
-      { type: "number"; value: "1" },
+      { type: "number"; value: 1 },
       { type: "operator"; value: "|" },
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "|" },
-      { type: "number"; value: "4" }
+      { type: "number"; value: 4 }
     ]
   >
 >;
@@ -777,22 +777,22 @@ type TokenOrChain = Expect<
 /**
  * 39. Mixed OR and AND
  * "1 | 2 & 3" => [
- *   { type: "number"; value: "1" },
+ *   { type: "number"; value: 1 },
  *   { type: "operator"; value: "|" },
- *   { type: "number"; value: "2" },
+ *   { type: "number"; value: 2 },
  *   { type: "operator"; value: "&" },
- *   { type: "number"; value: "3" }
+ *   { type: "number"; value: 3 }
  * ]
  */
 type TokenOrAndMix = Expect<
   Equal<
     Tokenize<"1 | 2 & 3">,
     [
-      { type: "number"; value: "1" },
+      { type: "number"; value: 1 },
       { type: "operator"; value: "|" },
-      { type: "number"; value: "2" },
+      { type: "number"; value: 2 },
       { type: "operator"; value: "&" },
-      { type: "number"; value: "3" }
+      { type: "number"; value: 3 }
     ]
   >
 >;
@@ -800,18 +800,18 @@ type TokenOrAndMix = Expect<
 /**
  * 40. Bitwise OR with zero
  * "0 | 7" => [
- *   { type: "number"; value: "0" },
+ *   { type: "number"; value: 0 },
  *   { type: "operator"; value: "|" },
- *   { type: "number"; value: "7" }
+ *   { type: "number"; value: 7 }
  * ]
  */
 type TokenOrZero = Expect<
   Equal<
     Tokenize<"0 | 7">,
     [
-      { type: "number"; value: "0" },
+      { type: "number"; value: 0 },
       { type: "operator"; value: "|" },
-      { type: "number"; value: "7" }
+      { type: "number"; value: 7 }
     ]
   >
 >;
@@ -819,22 +819,22 @@ type TokenOrZero = Expect<
 /**
  * 41. Mixed precedence chain
  * "4 & 1 | 2" => [
- *   { type: "number"; value: "4" },
+ *   { type: "number"; value: 4 },
  *   { type: "operator"; value: "&" },
- *   { type: "number"; value: "1" },
+ *   { type: "number"; value: 1 },
  *   { type: "operator"; value: "|" },
- *   { type: "number"; value: "2" }
+ *   { type: "number"; value: 2 }
  * ]
  */
 type TokenMixPrecedence = Expect<
   Equal<
     Tokenize<"4 & 1 | 2">,
     [
-      { type: "number"; value: "4" },
+      { type: "number"; value: 4 },
       { type: "operator"; value: "&" },
-      { type: "number"; value: "1" },
+      { type: "number"; value: 1 },
       { type: "operator"; value: "|" },
-      { type: "number"; value: "2" }
+      { type: "number"; value: 2 }
     ]
   >
 >;


### PR DESCRIPTION
## Summary
- parse numbers from token strings into numeric literals
- adjust token tests for numeric literal output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840974bed048322b55e18f78064c507