### PR TITLE
Add extra ternary expression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@
 
 | Capability | Details |
 |------------|---------|
-| Tokenisation | Splits input into `NumberToken`, `OperatorToken`, and `ParenToken` at the type level. Supported operators: `+ - * / % ^ & \|`. |
+| Tokenisation | Splits input into `NumberToken`, `OperatorToken`, and `ParenToken` at the type level. Supported operators include arithmetic, bitwise, comparison, and ternary tokens. |
 | Parser | Recursive-descent parser with correct precedence, associativity, parentheses, and unary ± support. Produces a canonical AST string. |
 | Evaluator | Delegates arithmetic to [`ts-arithmetic`](https://github.com/arielhs/ts-arithmetic) for arbitrary-precision math at the type level. |
 | Decimals & negatives | Works with decimal literals and unary operators out of the box. |
+| Comparisons & conditional | Supports `>`, `<`, `>=`, `<=`, `==`, `!=` and the `?:` ternary operator. |
 | Extensive tests | Dozens of compile-time test cases cover tricky edge cases. |
 | MIT-licensed | Free for personal and commercial use. |
 
@@ -50,6 +51,8 @@ type B = TypeExpr<"(5 + 3) * 2">;     // 16
 type C = TypeExpr<"-(7 % 4) * 3">;    // -9
 type D = TypeExpr<"5 & 3">;           // 1
 type E = TypeExpr<"5 | 2">;           // 7
+type F = TypeExpr<"3 > 2">;           // true
+type G = TypeExpr<"1 > 2 ? 8 : 9">;  // 9
 ```
 
 These correspond to the reference tests in the source.

--- a/tests/evaluate.test.ts
+++ b/tests/evaluate.test.ts
@@ -341,3 +341,27 @@ type EvalEquality = Expect<Equal<Evaluate<"==(+(n:3,n:2),n:5)">, true>>;
  * "?:(>(n:1,n:2),n:8,n:9)" => 9
  */
 type EvalTernary = Expect<Equal<Evaluate<"?:(>(n:1,n:2),n:8,n:9)">, 9>>;
+
+/**
+ * 49. Ternary true branch
+ * "?:(==(n:2,n:2),n:10,n:20)" => 10
+ */
+type EvalTernaryTrue = Expect<
+  Equal<Evaluate<"?:(==(n:2,n:2),n:10,n:20)">, 10>
+>;
+
+/**
+ * 50. Ternary false branch
+ * "?:(<(n:2,n:1),n:10,n:20)" => 20
+ */
+type EvalTernaryFalse = Expect<
+  Equal<Evaluate<"?:(<(n:2,n:1),n:10,n:20)">, 20>
+>;
+
+/**
+ * 51. Nested ternary
+ * "?:(>(n:1,n:2),n:1,?:(>(n:3,n:2),n:2,n:3))" => 2
+ */
+type EvalNestedTernary = Expect<
+  Equal<Evaluate<"?:(>(n:1,n:2),n:1,?:(>(n:3,n:2),n:2,n:3))">, 2>
+>;

--- a/tests/expression_string.test.ts
+++ b/tests/expression_string.test.ts
@@ -207,72 +207,92 @@ type ExprBitwiseAnd = Expect<Equal<TypeExpr<"5 & 3">, 1>>;
 
 
 /**
- * 34. Bitwise AND
+ * 35. Bitwise AND
  * "13 & 11" => 9
  */
 type ExprBitwiseAndLarge = Expect<Equal<TypeExpr<"13 & 11">, 9>>;
 /**
- * 35. Bitwise AND with zero
+ * 36. Bitwise AND with zero
  * "7 & 0" => 0
  */
 type ExprBitwiseAndZero = Expect<Equal<TypeExpr<"7 & 0">, 0>>;
 
 /**
- * 36. Bitwise AND chain
+ * 37. Bitwise AND chain
  * "15 & 7 & 3" => 3
  */
 type ExprBitwiseAndChain = Expect<Equal<TypeExpr<"15 & 7 & 3">, 3>>;
 
 /**
- * 37. Bitwise AND nested chain
+ * 38. Bitwise AND nested chain
  * "8 & 6 & 1" => 0
  */
 type ExprBitwiseAndNested = Expect<Equal<TypeExpr<"8 & 6 & 1">, 0>>;
 
 /**
- * 38. Bitwise OR
+ * 39. Bitwise OR
  * "5 | 3" => 7
  */
 type ExprBitwiseOr = Expect<Equal<TypeExpr<"5 | 3">, 7>>;
 
 /**
- * 39. Bitwise OR chain
+ * 40. Bitwise OR chain
  * "1 | 2 | 4" => 7
  */
 type ExprBitwiseOrChain = Expect<Equal<TypeExpr<"1 | 2 | 4">, 7>>;
 
 /**
- * 40. Bitwise OR with zero
+ * 41. Bitwise OR with zero
  * "0 | 7" => 7
  */
 type ExprBitwiseOrZero = Expect<Equal<TypeExpr<"0 | 7">, 7>>;
 
 /**
- * 41. Mixed OR and AND
+ * 42. Mixed OR and AND
  * "4 & 1 | 2" => 2
  */
 type ExprMixedPrecedence = Expect<Equal<TypeExpr<"4 & 1 | 2">, 2>>;
 
 /**
- * 42. Bitwise OR multiple operands
+ * 43. Bitwise OR multiple operands
  * "0 | 1 | 8" => 9
  */
 type ExprBitwiseOrMulti = Expect<Equal<TypeExpr<"0 | 1 | 8">, 9>>;
 
 /**
- * 43. Simple comparison
+ * 44. Simple comparison
  * "3 > 2" => true
  */
 type ExprSimpleComparison = Expect<Equal<TypeExpr<"3 > 2">, true>>;
 
 /**
- * 44. Equality with arithmetic
+ * 45. Equality with arithmetic
  * "3 + 2 == 5" => true
  */
 type ExprEquality = Expect<Equal<TypeExpr<"3 + 2 == 5">, true>>;
 
 /**
- * 45. Ternary conditional
+ * 46. Ternary conditional
  * "1 > 2 ? 8 : 9" => 9
  */
 type ExprTernary = Expect<Equal<TypeExpr<"1 > 2 ? 8 : 9">, 9>>;
+
+/**
+ * 47. Conditional true branch
+ * "2 == 2 ? 10 : 20" => 10
+ */
+type ExprTernaryTrue = Expect<Equal<TypeExpr<"2 == 2 ? 10 : 20">, 10>>;
+
+/**
+ * 48. Conditional false branch
+ * "2 < 1 ? 10 : 20" => 20
+ */
+type ExprTernaryFalse = Expect<Equal<TypeExpr<"2 < 1 ? 10 : 20">, 20>>;
+
+/**
+ * 49. Nested ternary
+ * "1 > 2 ? 1 : 3 > 2 ? 2 : 3" => 2
+ */
+type ExprNestedTernary = Expect<
+  Equal<TypeExpr<"1 > 2 ? 1 : 3 > 2 ? 2 : 3">, 2>
+>;

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -292,3 +292,30 @@ type ParseEqualityComparison = Expect<
 type ParseTernary = Expect<
   Equal<ToAstString<"1 > 2 ? 8 : 9">, "?:(>(n:1,n:2),n:8,n:9)">
 >;
+
+/**
+ * 46. Ternary with true branch
+ * "2 == 2 ? 10 : 20" => "?:(==(n:2,n:2),n:10,n:20)"
+ */
+type ParseTernaryTrue = Expect<
+  Equal<ToAstString<"2 == 2 ? 10 : 20">, "?:(==(n:2,n:2),n:10,n:20)">
+>;
+
+/**
+ * 47. Ternary with false branch
+ * "2 < 1 ? 10 : 20" => "?:(<(n:2,n:1),n:10,n:20)"
+ */
+type ParseTernaryFalse = Expect<
+  Equal<ToAstString<"2 < 1 ? 10 : 20">, "?:(<(n:2,n:1),n:10,n:20)">
+>;
+
+/**
+ * 48. Nested ternary
+ * "1 > 2 ? 1 : 3 > 2 ? 2 : 3" => "?:(>(n:1,n:2),n:1,?:(>(n:3,n:2),n:2,n:3))"
+ */
+type ParseNestedTernary = Expect<
+  Equal<
+    ToAstString<"1 > 2 ? 1 : 3 > 2 ? 2 : 3">,
+    "?:(>(n:1,n:2),n:1,?:(>(n:3,n:2),n:2,n:3))"
+  >
+>;

--- a/tests/tokenize.test.ts
+++ b/tests/tokenize.test.ts
@@ -838,3 +838,30 @@ type TokenMixPrecedence = Expect<
     ]
   >
 >;
+
+/**
+ * 42. Ternary conditional tokens
+ * "1 > 2 ? 3 : 4" => [
+ *   { type: "number"; value: 1 },
+ *   { type: "operator"; value: ">" },
+ *   { type: "number"; value: 2 },
+ *   { type: "operator"; value: "?" },
+ *   { type: "number"; value: 3 },
+ *   { type: "operator"; value: ":" },
+ *   { type: "number"; value: 4 }
+ * ]
+ */
+type TokenTernary = Expect<
+  Equal<
+    Tokenize<"1 > 2 ? 3 : 4">,
+    [
+      { type: "number"; value: 1 },
+      { type: "operator"; value: ">" },
+      { type: "number"; value: 2 },
+      { type: "operator"; value: "?" },
+      { type: "number"; value: 3 },
+      { type: "operator"; value: ":" },
+      { type: "number"; value: 4 }
+    ]
+  >
+>;


### PR DESCRIPTION
## Summary
- extend tests for evaluating ternary expressions
- add matching tests for expression strings and parsing
- cover tokenization of `?` and `:` operators
- fix numbering in expression string tests
- document comparison and ternary features in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a7be998083229b7f8aa36055d717